### PR TITLE
Update .env.example with new n8n API webhook URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # n8n API Configuration
-VITE_N8N_API_URL=http://localhost:5678/webhook
+VITE_N8N_API_URL=https://n8n.kqsys.com/webhook-test
 
 # Development Settings
 VITE_ENV=development
 VITE_DEBUG=true
 
 # Production Settings (for Cloudflare Pages)
-# VITE_N8N_API_URL=https://your-n8n-instance.com/webhook
+# VITE_N8N_API_URL=https://n8n.kqsys.com/webhook-test
 # VITE_ENV=production
 # VITE_DEBUG=false


### PR DESCRIPTION
## Summary
- Updated the n8n API webhook URL in the `.env.example` file to point to the new test endpoint

## Changes

### Configuration
- Changed `VITE_N8N_API_URL` from `http://localhost:5678/webhook` to `https://n8n.kqsys.com/webhook-test` for development and production settings

## Test plan
- Verify that the application correctly uses the updated webhook URL from the environment configuration during development and production builds
- Ensure no disruption in webhook communication with the new URL

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a38465e7-2d55-4a7f-bfe2-1a01b4aafc8c